### PR TITLE
new querySelector for autoplayButton

### DIFF
--- a/content.js
+++ b/content.js
@@ -16,7 +16,7 @@ function disableAutoplayV3(retryCount) {
   }
 
   var autoplayButton = document.querySelector(
-    '[data-tooltip-target-id="ytp-autonav-toggle-button"]'
+    '[aria-label="Autoplay is on"]'
   );
 
   if (document.readyState !== "complete") {


### PR DESCRIPTION
The current selector does not distinguish between autoplay off or autoplay on state. Hence it will always do a click event effectively switching between on and off.
Should fix #4